### PR TITLE
ensure skipping chunks that are already uploaded

### DIFF
--- a/swift_upload_runner/upload.py
+++ b/swift_upload_runner/upload.py
@@ -256,6 +256,9 @@ class ResumableFileUploadProxy:
         while len(self.done_chunks) < self.total_chunks:
             chunk_number, segment = await self.q.get()
 
+            if chunk_number in self.done_chunks:
+                continue
+
             LOGGER.debug(f"Got chunk from chunk {chunk_number}")
 
             chunk_reader = segment["data"]


### PR DESCRIPTION
### Description
Cancellations and poor internet connection can lead to repeats of the chunks. This update takes care of repeated chunks.

### Changelog
* Skip repeated chunks
